### PR TITLE
Decode Supabase cookie in middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,29 @@
 import { createServerClient } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
 
+function parseSessionCookie(value: string) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    try {
+      return JSON.parse(Buffer.from(value, 'base64').toString('utf-8'));
+    } catch {
+      return null;
+    }
+  }
+}
+
+function decodeJwt(token: string) {
+  try {
+    const payload = JSON.parse(
+      Buffer.from(token.split('.')[1], 'base64').toString('utf-8')
+    );
+    return payload as { sub?: string; exp?: number };
+  } catch {
+    return null;
+  }
+}
+
 export async function middleware(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
     request,
@@ -31,14 +54,13 @@ export async function middleware(request: NextRequest) {
 
   const isAuthPath =
     request.nextUrl.pathname.startsWith('/auth') ||
-    request.nextUrl.pathname.startsWith('/api/auth') ||
-    request.nextUrl.pathname === '/';
+    request.nextUrl.pathname.startsWith('/api/auth');
 
-  const hasSessionCookie = request.cookies
+  const sessionCookie = request.cookies
     .getAll()
-    .some(cookie => cookie.name.startsWith('sb-'));
+    .find(cookie => cookie.name.startsWith('sb-'));
 
-  if (!hasSessionCookie) {
+  if (!sessionCookie) {
     if (!isAuthPath) {
       const url = request.nextUrl.clone();
       url.pathname = '/auth/login';
@@ -47,14 +69,29 @@ export async function middleware(request: NextRequest) {
     return supabaseResponse;
   }
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const session = parseSessionCookie(sessionCookie.value);
+  const accessToken =
+    session?.access_token ?? session?.currentSession?.access_token;
+  const expiresAt =
+    session?.expires_at ?? session?.currentSession?.expires_at ?? 0;
 
-  if (!user && !isAuthPath) {
-    const url = request.nextUrl.clone();
-    url.pathname = '/auth/login';
-    return NextResponse.redirect(url);
+  const decoded = accessToken ? decodeJwt(accessToken) : null;
+  const userId = decoded?.sub;
+  const expired = !decoded?.exp
+    ? true
+    : Date.now() >= (expiresAt ? expiresAt * 1000 : decoded.exp * 1000);
+
+  if (!userId || expired) {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user && !isAuthPath) {
+      const url = request.nextUrl.clone();
+      url.pathname = '/auth/login';
+      return NextResponse.redirect(url);
+    }
+    return supabaseResponse;
   }
 
   // IMPORTANT: You *must* return the supabaseResponse object as it is. If you're
@@ -70,13 +107,9 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    /*
-     * Match all request paths except for the ones starting with:
-     * - _next/static (static files)
-     * - _next/image (image optimization files)
-     * - favicon.ico (favicon file)
-     * Feel free to modify this pattern to include more paths.
-     */
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/dashboard/:path*',
+    '/teacher/:path*',
+    '/admin/:path*',
+    '/api/:path*',
   ],
 };


### PR DESCRIPTION
## Summary
- Decode Supabase `sb-` session cookie locally to obtain user ID and expiry
- Only call `supabase.auth.getUser` when token is missing or expired
- Limit middleware to `/dashboard`, `/teacher`, `/admin`, and `/api` routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npx ts-node --compiler-options '{"module":"commonjs"}' middleware.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b9ce29e910832d95d286ec8e0edf3c